### PR TITLE
Chore/create run

### DIFF
--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -1,0 +1,18 @@
+---
+name: lint yaml files
+
+"on":
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lintAllTheThings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .github/yaml-lint/.config.yaml

--- a/.github/yaml-lint/.config.yaml
+++ b/.github/yaml-lint/.config.yaml
@@ -1,0 +1,8 @@
+config_data: |
+  extends: default
+  rules:
+    new-line-at-end-of-file:
+      level: warning
+    line-length:
+      max: 120
+      level: warning

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@prefecthq/platform

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# actions-updatecli-minor-run
-Actions that runs updatecli, commits those changes if they exist, and opens a PR
+# actions-updatecli-apply
+## Description
+Action that runs updatecli, commits those changes if they exist, and opens a PR
+
+## Inputs
+| Input | Desription | Required |
+|-------|------------|----------|
+| manifest-path | Path to the updatecli manifest file. | true |
+| run-type | The type of updatecli run to perform. (major or minor) | true |
+
+## Usage
+```yaml
+name: updatecli-minor
+"on":
+  schedule:
+    #       ┌───────────── minute (0 - 59)
+    #       │  ┌───────────── hour (0 - 23)
+    #       │  │  ┌───────────── day of the month (1 - 31)
+    #       │  │  │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #       │  │  │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #       │  │  │ │ │
+    #       │  │  │ │ │
+    #       │  │  │ │ │
+    - cron: 0 15 * * 1  # Monday @ 3pm UTC
+  workflow_dispatch:
+# Do not grant jobs any permissions by default
+permissions: {}
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    permissions:
+      # required to write to the repo
+      contents: write
+      # required to open a pr with updatecli changes
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: updatecli-apply
+        uses: prefecthq/actions-updatecli-apply
+        with:
+          manifest-path: '.github/updatecli/manifest-minor.yaml'
+          run-type: 'minor'
+```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: updatecli-apply
-        uses: prefecthq/actions-updatecli-apply
+        uses: prefecthq/actions-updatecli-apply@main
         with:
           manifest-path: '.github/updatecli/manifest-minor.yaml'
           run-type: 'minor'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Action that runs updatecli, commits those changes if they exist, and opens a PR
 ## Inputs
 | Input | Desription | Required |
 |-------|------------|----------|
+| github-token | The GitHub token to use for authentication. | true |
 | manifest-path | Path to the updatecli manifest file. | true |
 | run-type | The type of updatecli run to perform. (major or minor) | true |
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,60 @@
+---
+name: Run updatecli and push to git
+author: PrefectHQ
+description: This action will run updatecli and push the changes to git and will also open a PR
+inputs:
+  manifest-path:
+    description: "Path to the updatecli manifest file"
+    default: ".github/updatecli/manifest-minor.yaml"
+    required: false
+  run-type:
+    description: "The type of updatecli run to perform (major or minor)"
+    default: "minor"
+    required: false
+runs:
+  using: composite
+  steps:
+    - id: configure_git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      shell: bash
+
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: create branch for dependency version updates
+      run: git checkout -b "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
+      shell: bash
+
+    - name: install updatecli in the runner
+      uses: updatecli/updatecli-action@v2
+
+    - name: run updatecli in apply mode
+      id: updatecli_apply
+      run: |
+        updatecli apply --config .github/updatecli/manifest.yaml --experimental
+        if [[ $(git diff --name-only | wc -l) -eq 0 ]]; then
+          echo "No changes detected, exiting"
+          echo "changes=false" >> $GITHUB_OUTPUT
+          exit 0
+        else
+          echo "changes=true" >> $GITHUB_OUTPUT
+        fi
+        git add .
+        git commit -m "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
+        git push --set-upstream origin "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      shell: bash
+
+    - name: create pr
+      if: steps.updatecli_apply.outputs.changes == 'true'
+      run: |
+        git checkout "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
+        gh pr create --base main --title "dependency-version-${{ inputs.run-type }}-bump-${{ steps.date.outputs.date }}" -f --label soc2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -51,7 +51,7 @@ runs:
         git commit -m "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
         git push --set-upstream origin "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
 
     - name: create pr
@@ -60,5 +60,5 @@ runs:
         git checkout "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
         gh pr create --base main --title "dependency-version-${{ inputs.run-type }}-bump-${{ steps.date.outputs.date }}" -f --label soc2
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -3,14 +3,18 @@ name: Run updatecli and push to git
 author: PrefectHQ
 description: This action will run updatecli and push the changes to git and will also open a PR
 inputs:
+  github-token:
+    description: "The GitHub token to use for authentication"
+    default: ${{ github.token }}
+    required: true
   manifest-path:
     description: "Path to the updatecli manifest file"
     default: ".github/updatecli/manifest-minor.yaml"
-    required: false
+    required: true
   run-type:
     description: "The type of updatecli run to perform (major or minor)"
     default: "minor"
-    required: false
+    required: true
 runs:
   using: composite
   steps:


### PR DESCRIPTION
- Relates: https://github.com/PrefectHQ/platform/issues/5625
- Creates shareable GHA for updatecli runs since major and minor are identical just with different manifests and schedules
- Example run: https://github.com/PrefectHQ/flows/actions/runs/7391218314/job/20107588255