### PR TITLE
Chore/infer github token from run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Action that runs updatecli, commits those changes if they exist, and opens a PR
 ## Inputs
 | Input | Description | Required |
 |-------|------------|----------|
-| github-token | The GitHub token to use for authentication. | true |
 | manifest-path | Path to the updatecli manifest file. | true |
 | run-type | The type of updatecli run to perform. (major or minor) | true |
 

--- a/action.yaml
+++ b/action.yaml
@@ -39,10 +39,10 @@ runs:
         if [[ $(git diff --name-only | wc -l) -eq 0 ]]; then
           echo "No changes detected, exiting"
           echo "changes=false" >> $GITHUB_OUTPUT
+          exit 0
         else
           echo "changes=true" >> $GITHUB_OUTPUT
         fi
-        touch text.txt
         git add .
         git commit -m "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
         git push --set-upstream origin "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"

--- a/action.yaml
+++ b/action.yaml
@@ -3,10 +3,6 @@ name: Run updatecli and push to git
 author: PrefectHQ
 description: This action will run updatecli and push the changes to git and will also open a PR
 inputs:
-  github-token:
-    description: "The GitHub token to use for authentication"
-    default: ${{ github.token }}
-    required: true
   manifest-path:
     description: "Path to the updatecli manifest file"
     default: ".github/updatecli/manifest-minor.yaml"
@@ -43,15 +39,15 @@ runs:
         if [[ $(git diff --name-only | wc -l) -eq 0 ]]; then
           echo "No changes detected, exiting"
           echo "changes=false" >> $GITHUB_OUTPUT
-          exit 0
         else
           echo "changes=true" >> $GITHUB_OUTPUT
         fi
+        touch text.txt
         git add .
         git commit -m "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
         git push --set-upstream origin "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ github.token }}
       shell: bash
 
     - name: create pr
@@ -60,5 +56,5 @@ runs:
         git checkout "dependency-version-${{ inputs.run-type }}-${{ steps.date.outputs.date }}"
         gh pr create --base main --title "dependency-version-${{ inputs.run-type }}-bump-${{ steps.date.outputs.date }}" -f --label soc2
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ github.token }}
       shell: bash


### PR DESCRIPTION
- Relates: https://github.com/PrefectHQ/platform/issues/5625
- It looks like the github token does in fact get inferred when calling a shared workflow so we do not need to pass as an input