### PR TITLE
chore: set git user as github-actions[bot]

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,8 +16,8 @@ runs:
   steps:
     - id: configure_git
       run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
       shell: bash
 
     - name: Get current date


### PR DESCRIPTION
https://github.com/orgs/community/discussions/25067

on `schedule` triggers, `$GITHUB_ACTOR` will be the last user that set that trigger.  this PR will make it so that we can have this user to always be the github action bot, instead of a human user