### PR TITLE
chore: bump updatecli-action to 2.85.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
       shell: bash
 
     - name: Install updatecli in the runner
-      uses: updatecli/updatecli-action@v2.84.0
+      uses: updatecli/updatecli-action@v2.85.0
 
     - name: Run updatecli in apply mode
       run: |


### PR DESCRIPTION
https://github.com/updatecli/updatecli-action/releases

Related to https://linear.app/prefect/issue/PLA-1537/fix-failed-updatecli-workflow