### PR TITLE
Fix helm-docs step failing when there are no changes

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -69,8 +69,10 @@ runs:
       if: inputs.run-helm-docs == 'true' && env.CHANGES == 'true'
       run: |
         helm-docs --template-files=README.md.gotmpl
-        git commit -am "helm-docs"
-        git push
+        if [[ $(git diff --name-only | wc -l) -gt 0 ]]; then
+          git commit -am "helm-docs"
+          git push
+        fi
       shell: bash
 
     - name: Create PR


### PR DESCRIPTION
The helm-docs step was failing with exit code 1 when there were no documentation changes to commit. This occurred because the shell's `set -e` flag (from the default bash configuration) causes immediate exit on any non-zero exit code, and `git commit` returns 1 when there's nothing to commit.

This fix adds a check for actual file changes before attempting to commit and push. If helm-docs doesn't generate any changes, the step now completes successfully without trying to commit.

Related: https://github.com/PrefectHQ/prefect-operator/actions/runs/18656329028/job/53186252489